### PR TITLE
#9: Add gravitas handling to beat and aside.

### DIFF
--- a/screenpy_adapter_allure/adapters.py
+++ b/screenpy_adapter_allure/adapters.py
@@ -59,9 +59,13 @@ class AllureAdapter:
             func = allure.severity(self.GRAVITAS[gravitas])(func)
         yield func
 
-    def beat(self, func: Callable, line: str) -> Generator:
+    def beat(
+        self, func: Callable, line: str, gravitas: Optional[str] = None
+    ) -> Generator:
         """Encapsulate the beat within Allure's step context."""
         allure_step = allure.step(line)
+        if gravitas is not None:
+            func = allure.severity(self.GRAVITAS[gravitas])(func)
         try:
             with allure_step:
                 self.step_stack.append(allure_step)
@@ -73,8 +77,12 @@ class AllureAdapter:
                 # ... but if it's a different KeyError, we want to reraise.
                 raise
 
-    def aside(self, func: Callable, line: str) -> Generator:
+    def aside(
+        self, func: Callable, line: str, gravitas: Optional[str] = None
+    ) -> Generator:
         """Encapsulate the aside within Allure's step context."""
+        if gravitas is not None:
+            func = allure.severity(self.GRAVITAS[gravitas])(func)
         with allure.step(line):
             yield func
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -40,14 +40,18 @@ class TestAllureAdapter:
         mocked_allure.feature.assert_called_once_with(scene_name)
         mocked_allure.severity.assert_called_once_with(allure_level)
 
-    def test_beat(self, mocked_allure):
+    @pytest.mark.parametrize(
+        "narrator_level,allure_level", AllureAdapter.GRAVITAS.items()
+    )
+    def test_beat(self, mocked_allure, narrator_level, allure_level):
         adapter = AllureAdapter()
         beat_message = "test beat"
-        test_func = adapter.beat(prop, beat_message)
+        test_func = adapter.beat(prop, beat_message, narrator_level)
 
         next(test_func)()
 
         mocked_allure.step.assert_called_once_with(beat_message)
+        mocked_allure.severity.assert_called_once_with(allure_level)
 
     def test_embedded_beat_allure_message(self, mocked_allure):
         """Context deepens with the embedded beats."""
@@ -72,14 +76,18 @@ class TestAllureAdapter:
         assert calls[7][0] == "().__exit__"
         assert calls[8][0] == "().__exit__"
 
-    def test_aside(self, mocked_allure):
+    @pytest.mark.parametrize(
+        "narrator_level,allure_level", AllureAdapter.GRAVITAS.items()
+    )
+    def test_aside(self, mocked_allure, narrator_level, allure_level):
         adapter = AllureAdapter()
         aside_message = "test aside"
-        test_func = adapter.aside(prop, aside_message)
+        test_func = adapter.aside(prop, aside_message, narrator_level)
 
         next(test_func)()
 
         mocked_allure.step.assert_called_once_with(aside_message)
+        mocked_allure.severity.assert_called_once_with(allure_level)
 
     def test_error(self, mocked_manager, mock_allure_trappings):
         adapter = AllureAdapter()


### PR DESCRIPTION
After a recent update to `screenpy_requests`, we now have places where we use `aside` and `beat` with `gravitas`. The built-in `StdOutAdapter` was updated to handle this, but the `AllureAdapter` was forgotten! This PR adds handling for gravitas in Allure.

Thanks to @jardilac91 for reporting this one!